### PR TITLE
Allow Manually Setting Order of Players

### DIFF
--- a/src/parse.py
+++ b/src/parse.py
@@ -492,7 +492,6 @@ def write_tournament_info_to_sheet():
 
 def main():
     start = time.time()
-    write_copy_badge_count_from_sheet()
     for player_name, player_url in get_player_tags_urls_list():
         logger.debug("parsing, player_name=" + player_name)
         player_id = url_to_id(player_url)

--- a/src/parse.py
+++ b/src/parse.py
@@ -12,7 +12,6 @@ from scrape import (
     get_duplicate_dict_from_sheet,
     get_banned_tournament_ids,
     get_player_swapper_dict,
-    write_copy_badge_count_from_sheet,
 )
 import gspread
 from gspread_formatting import *
@@ -85,7 +84,6 @@ def add_tag(player_id: str, tag: str):
 
 
 COMBINE_LOOKUP = get_duplicate_dict_from_sheet()
-BADGE_COUNT_OVERRIDE = get_copy_badge_count_from_sheet()
 
 
 def player_to_player_history(player_id, opponent_id):

--- a/src/parse.py
+++ b/src/parse.py
@@ -12,6 +12,7 @@ from scrape import (
     get_duplicate_dict_from_sheet,
     get_banned_tournament_ids,
     get_player_swapper_dict,
+    write_copy_badge_count_from_sheet,
 )
 import gspread
 from gspread_formatting import *
@@ -84,6 +85,7 @@ def add_tag(player_id: str, tag: str):
 
 
 COMBINE_LOOKUP = get_duplicate_dict_from_sheet()
+BADGE_COUNT_OVERRIDE = get_copy_badge_count_from_sheet()
 
 
 def player_to_player_history(player_id, opponent_id):
@@ -490,6 +492,7 @@ def write_tournament_info_to_sheet():
 
 def main():
     start = time.time()
+    write_copy_badge_count_from_sheet()
     for player_name, player_url in get_player_tags_urls_list():
         logger.debug("parsing, player_name=" + player_name)
         player_id = url_to_id(player_url)

--- a/src/scrape.py
+++ b/src/scrape.py
@@ -179,7 +179,7 @@ def write_copy_badge_count_from_sheet() -> dict:
             continue
         b = url_to_id(copy_url)
         id2idmap[a] = b
-    r.set("copy_badge_count_from", json.dumps(id2idmap))
+    r.set("copy_badge_count_from", json.dumps(id2idmap), ex=timedelta(days=3))
 
 
 def get_or_set_player_badge_count(player_id: str, copy_dict=None) -> int:

--- a/src/scrape.py
+++ b/src/scrape.py
@@ -205,7 +205,7 @@ def get_or_set_player_badge_count(player_id: str, copy_dict=None) -> float:
     badge_key = f"{player_id}:num_badges"
     in_db = r.get(badge_key)
     if in_db is not None:
-        return int(in_db)
+        return float(in_db)
     data = fetch_url_with_retry(
         f"https://api.pgstats.com/players/profile?playerId={player_id}&game=melee"
     ).json()

--- a/src/scrape.py
+++ b/src/scrape.py
@@ -203,6 +203,7 @@ def get_or_set_player_badge_count(player_id: str, copy_dict=None) -> int:
 @click.command()
 @click.option("--skip", is_flag=True, default=False, help="skip players already in db")
 def main(skip):
+    write_copy_badge_count_from_sheet()
     scrape_all_players(skip_known=skip)
 
 


### PR DESCRIPTION
This is a hacky way to copy player badge counts to other players to improve the order of the PR sheet. We still use the heuristic of badge counts to roughly order players, but this lets us correct where needed by pushing players up or down.

The offset is so that the badge count is slightly lower than the player copying from.

https://docs.google.com/spreadsheets/d/1EQmk2ElCjlC6LiYrmqBcjxpAHL49PTgJRuOwcY1MlPY/edit?gid=0#gid=0